### PR TITLE
C2-19 Creating a basic logging package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,16 @@
-module backend
+module github.com/SENG-499-Company2-B01/Backend
 
 go 1.20
 
 require (
 	github.com/gorilla/mux v1.8.0
+	github.com/joho/godotenv v1.5.1
 	go.mongodb.org/mongo-driver v1.11.6
 	golang.org/x/text v0.3.8
 )
 
 require (
 	github.com/golang/snappy v0.0.1 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,7 +47,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,74 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"log"
+	"path/filepath"
+	"runtime"
+	"errors"
+)
+
+var (
+	infoLogger    *log.Logger
+	warningLogger *log.Logger
+	errorLogger   *log.Logger
+
+	// Flag to control program termination on error log
+	exitOnError = true
+)
+
+// Initializes the loggers with their respective outputs and formats.
+func InitLogger(infoOutput, warningOutput, errorOutput io.Writer) error {
+	infoLogger = log.New(infoOutput, "", log.Ldate|log.Ltime)
+	warningLogger = log.New(warningOutput, "", log.Ldate|log.Ltime)
+	errorLogger = log.New(errorOutput, "", log.Ldate|log.Ltime)
+
+	// Check if any of the loggers failed to initialize
+	if infoLogger == nil || warningLogger == nil || errorLogger == nil {
+		return errors.New("Error initializing logger")
+	}
+
+	return nil
+}
+
+// Returns the file and line number of the calling function.
+func getFileLine() string {
+	_, file, line, _ := runtime.Caller(2) // Skip two frames: getFileLine() and the calling function
+	return fmt.Sprintf("%s:%d", filepath.Base(file), line)
+}
+
+// SetExitOnError sets the behavior of program termination on error logs.
+// If exit is true, the program will exit on error logs.
+// If exit is false, the program will not exit on error logs.
+func SetExitOnError(exit bool) {
+	exitOnError = exit
+}
+
+// Info logs an information message to the console with the file and line number.
+func Info(message string) {
+	// Print the information message to the console and colour the tag blue
+	infoLogger.Println("\033[1;34m[INFO]\033[0m", message)
+}
+
+// Warning logs a warning message to the console with the file and line number.
+func Warning(message string) {
+	fileLine := getFileLine()
+
+	// Print the warning message to the console and colour the tag yellow
+	warningLogger.Println("\033[1;33m[WARNING]\033[0m", fileLine, message)
+}
+
+// Error logs an error message to the console with the file and line number.
+// If exitOnError flag is set, the program will exit after logging the error.
+func Error(err error) {
+	fileLine := getFileLine()
+
+	// Print the error to the console with the file and line number, and colour the tag red
+	errorLogger.Printf("\033[1;31m[ERROR]\033[0m %s %s", fileLine, err)
+
+	if exitOnError {
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,17 +3,17 @@ package main
 import (
 	"context"
 
-	// "encoding/json"
-	// "fmt"
 	"log"
+	// "fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 
-	"backend/modules/classrooms"
-	"backend/modules/courses"
-	"backend/modules/schedules"
-	"backend/modules/users"
+	"github.com/SENG-499-Company2-B01/Backend/logger"
+	"github.com/SENG-499-Company2-B01/Backend/modules/classrooms"
+	"github.com/SENG-499-Company2-B01/Backend/modules/courses"
+	"github.com/SENG-499-Company2-B01/Backend/modules/schedules"
+	"github.com/SENG-499-Company2-B01/Backend/modules/users"
 
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
@@ -24,13 +24,23 @@ import (
 var client *mongo.Client
 
 func init() {
-	// Get the current working directory
+	// Initialize the logger
 	var err error
+	err = logger.InitLogger(os.Stdout, os.Stdout, os.Stderr)
+	if err != nil {
+		// log.Fatal("Error initializing logger:", err)
+		logger.Error(err)
+		return
+	}
+
+	// Print a success message to the console
+	logger.Info("Logger initialized successfully!")
+
+	// Get the current working directory
 	dir, err := os.Getwd()
 	if err != nil {
 		log.Fatal("Error getting current working directory:", err)
 	}
-	log.Println("Current working directory:", dir)
 
 	// Construct the path to the .env file
 	envPath := filepath.Join(dir, ".env")
@@ -66,7 +76,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	log.Println("Connected to MongoDB!")
+	logger.Info("Connected to MongoDB successfully!")
 }
 
 func handleRequests() {
@@ -137,8 +147,6 @@ func handleRequests() {
 		schedules.DeleteSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
 	}).Methods(http.MethodDelete)
 
-	// Courses CRUD Operations
-
 	// Classroom CRUD Operations
 	router.HandleFunc("/classrooms", func(w http.ResponseWriter, r *http.Request) {
 		classrooms.CreateClassroom(w, r, client.Database("schedule_db").Collection("classrooms"))
@@ -170,5 +178,11 @@ func handleRequests() {
 // }
 
 func main() {
+	// // Example Logging messages
+	// logger.Info("This is an info message")
+	// logger.Warning("This is a warning message")
+	// logger.Error(fmt.Errorf("This is an error message"))
+	
+
 	handleRequests()
 }

--- a/main.go
+++ b/main.go
@@ -3,17 +3,17 @@ package main
 import (
 	"context"
 
-	// "encoding/json"
-	// "fmt"
 	"log"
+	// "fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 
-	"backend/modules/classrooms"
-	"backend/modules/courses"
-	"backend/modules/schedules"
-	"backend/modules/users"
+	"github.com/SENG-499-Company2-B01/Backend/logger"
+	"github.com/SENG-499-Company2-B01/Backend/modules/classrooms"
+	"github.com/SENG-499-Company2-B01/Backend/modules/courses"
+	"github.com/SENG-499-Company2-B01/Backend/modules/schedules"
+	"github.com/SENG-499-Company2-B01/Backend/modules/users"
 
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
@@ -24,13 +24,23 @@ import (
 var client *mongo.Client
 
 func init() {
-	// Get the current working directory
+	// Initialize the logger
 	var err error
+	err = logger.InitLogger(os.Stdout, os.Stdout, os.Stderr)
+	if err != nil {
+		// log.Fatal("Error initializing logger:", err)
+		logger.Error(err)
+		return
+	}
+
+	// Print a success message to the console
+	logger.Info("Logger initialized successfully!")
+
+	// Get the current working directory
 	dir, err := os.Getwd()
 	if err != nil {
 		log.Fatal("Error getting current working directory:", err)
 	}
-	log.Println("Current working directory:", dir)
 
 	// Construct the path to the .env file
 	envPath := filepath.Join(dir, ".env")
@@ -66,7 +76,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	log.Println("Connected to MongoDB!")
+	logger.Info("Connected to MongoDB successfully!")
 }
 
 func handleUserRequests(router *mux.Router) {
@@ -162,6 +172,11 @@ func handleScheduleRequests(router *mux.Router) {
 }
 
 func main() {
+	// // Example Logging messages
+	// logger.Info("This is an info message")
+	// logger.Warning("This is a warning message")
+	// logger.Error(fmt.Errorf("This is an error message"))
+
 	router := mux.NewRouter()
 
 	handleUserRequests(router)

--- a/main.go
+++ b/main.go
@@ -69,32 +69,7 @@ func init() {
 	log.Println("Connected to MongoDB!")
 }
 
-func handleRequests() {
-	router := mux.NewRouter()
-
-	// // Example handle request
-	// router.HandleFunc("/", homePage).Methods(http.MethodGet)
-
-	// Courses CRUD Operations
-	router.HandleFunc("/courses", func(w http.ResponseWriter, r *http.Request) {
-		courses.CreateCourse(w, r, client.Database("schedule_db").Collection("courses"))
-	}).Methods(http.MethodPost)
-
-	router.HandleFunc("/courses/{courseShortHand}", func(w http.ResponseWriter, r *http.Request) {
-		courses.GetCourse(w, r, client.Database("schedule_db").Collection("courses"))
-	}).Methods(http.MethodGet)
-
-	router.HandleFunc("/courses", func(w http.ResponseWriter, r *http.Request) {
-		courses.GetCourses(w, r, client.Database("schedule_db").Collection("courses"))
-	}).Methods(http.MethodGet)
-	router.HandleFunc("/courses/{courseShortHand}", func(w http.ResponseWriter, r *http.Request) {
-		courses.DeleteCourse(w, r, client.Database("schedule_db").Collection("courses"))
-	}).Methods(http.MethodDelete)
-
-	router.HandleFunc("/courses/{courseShortHand}", func(w http.ResponseWriter, r *http.Request) {
-		courses.UpdateCourse(w, r, client.Database("schedule_db").Collection("courses"))
-	}).Methods(http.MethodPut)
-
+func handleUserRequests(router *mux.Router) {
 	// Users CRUD Operations
 	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		users.CreateUser(w, r, client.Database("schedule_db").Collection("users"))
@@ -115,30 +90,9 @@ func handleRequests() {
 	router.HandleFunc("/users/{username}", func(w http.ResponseWriter, r *http.Request) {
 		users.DeleteUser(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodDelete)
+}
 
-	// Schedules CRUD Operations
-	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
-		schedules.CreateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodPost)
-
-	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodGet)
-
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GetSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodGet)
-
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.UpdateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodPut)
-
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.DeleteSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodDelete)
-
-	// Courses CRUD Operations
-
+func handleClassroomRequests(router *mux.Router) {
 	// Classroom CRUD Operations
 	router.HandleFunc("/classrooms", func(w http.ResponseWriter, r *http.Request) {
 		classrooms.CreateClassroom(w, r, client.Database("schedule_db").Collection("classrooms"))
@@ -159,16 +113,70 @@ func handleRequests() {
 	router.HandleFunc("/classrooms/{shorthand}/{room_number}", func(w http.ResponseWriter, r *http.Request) {
 		classrooms.DeleteClassroom(w, r, client.Database("schedule_db").Collection("classrooms"))
 	}).Methods(http.MethodDelete)
+}
+
+func handleCourseRequests(router *mux.Router) {
+	// Courses CRUD Operations
+	router.HandleFunc("/courses", func(w http.ResponseWriter, r *http.Request) {
+		courses.CreateCourse(w, r, client.Database("schedule_db").Collection("courses"))
+	}).Methods(http.MethodPost)
+
+	router.HandleFunc("/courses/{courseShortHand}", func(w http.ResponseWriter, r *http.Request) {
+		courses.GetCourse(w, r, client.Database("schedule_db").Collection("courses"))
+	}).Methods(http.MethodGet)
+
+	router.HandleFunc("/courses", func(w http.ResponseWriter, r *http.Request) {
+		courses.GetCourses(w, r, client.Database("schedule_db").Collection("courses"))
+	}).Methods(http.MethodGet)
+	
+	router.HandleFunc("/courses/{courseShortHand}", func(w http.ResponseWriter, r *http.Request) {
+		courses.DeleteCourse(w, r, client.Database("schedule_db").Collection("courses"))
+	}).Methods(http.MethodDelete)
+
+	router.HandleFunc("/courses/{courseShortHand}", func(w http.ResponseWriter, r *http.Request) {
+		courses.UpdateCourse(w, r, client.Database("schedule_db").Collection("courses"))
+	}).Methods(http.MethodPut)
+}
+
+func handleScheduleRequests(router *mux.Router) {
+	// Schedules CRUD Operations
+	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
+		schedules.CreateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+	}).Methods(http.MethodPost)
+
+	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
+		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("schedules"))
+	}).Methods(http.MethodGet)
+
+	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
+		schedules.GetSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+	}).Methods(http.MethodGet)
+
+	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
+		schedules.UpdateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+	}).Methods(http.MethodPut)
+
+	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
+		schedules.DeleteSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+	}).Methods(http.MethodDelete)
+}
+
+func main() {
+	router := mux.NewRouter()
+
+	handleUserRequests(router)
+	handleClassroomRequests(router)
+	handleCourseRequests(router)
+	handleScheduleRequests(router)
 
 	log.Fatal(http.ListenAndServe(":8000", router))
 }
+
+// // Example handle request
+// router.HandleFunc("/", homePage).Methods(http.MethodGet)
 
 // // Example Endpoint
 // func homePage(w http.ResponseWriter, r *http.Request) {
 // 	fmt.Fprintf(w, "Welcome to the HomePage!")
 // 	fmt.Println("Endpoint Hit: homePage")
 // }
-
-func main() {
-	handleRequests()
-}

--- a/tests/logger_test.go
+++ b/tests/logger_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/SENG-499-Company2-B01/Backend/logger"
 )
 
-func TestLogger(t *testing.T) {
+func TestLoggerInfo(t *testing.T) {
 	// Redirect log output to a buffer for testing
 	var buf bytes.Buffer
 
@@ -27,8 +27,19 @@ func TestLogger(t *testing.T) {
 		t.Errorf("Info log message:\nExpected: %q\nGot: %q", expectedInfo, got)
 	}
 
+	// Clean up
+	log.SetOutput(os.Stderr)
+}
+
+func TestLoggerWarning(t *testing.T) {
+	// Redirect log output to a buffer for testing
+	var buf bytes.Buffer
+
+	// Initialize the logger with the buffer as the output
+	logger.InitLogger(&buf, &buf, &buf)
+
 	// Test Warning
-	expectedWarning := "\033[1;33m[WARNING]\033[0m logger_test.go:32 TestWarningMessage"
+	expectedWarning := "\033[1;33m[WARNING]\033[0m logger_test.go:43 TestWarningMessage"
 	logger.Warning("TestWarningMessage")
 
 	// Verify Warning log message
@@ -36,11 +47,22 @@ func TestLogger(t *testing.T) {
 		t.Errorf("Warning log message:\nExpected: %q\nGot: %q", expectedWarning, got)
 	}
 
+	// Clean up
+	log.SetOutput(os.Stderr)
+}
+
+func TestLoggerError(t *testing.T) {
+	// Redirect log output to a buffer for testing
+	var buf bytes.Buffer
+
+	// Initialize the logger with the buffer as the output
+	logger.InitLogger(&buf, &buf, &buf)
+
 	// Turn off the exit on error to test successfully
 	logger.SetExitOnError(false)
 
 	// Test Error
-	expectedError := "\033[1;31m[ERROR]\033[0m logger_test.go:43 TestErrorMessage"
+	expectedError := "\033[1;31m[ERROR]\033[0m logger_test.go:66 TestErrorMessage"
 	logger.Error(fmt.Errorf("TestErrorMessage"))
 
 	// Turn back on the exit on error 
@@ -50,6 +72,9 @@ func TestLogger(t *testing.T) {
 	if got := extractLogMessage(buf.String()); got != expectedError {
 		t.Errorf("Error log message:\nExpected: %q\nGot: %q", expectedError, got)
 	}
+
+	// Clean up
+	log.SetOutput(os.Stderr)
 }
 
 func extractLogMessage(logOutput string) string {

--- a/tests/logger_test.go
+++ b/tests/logger_test.go
@@ -1,0 +1,81 @@
+package logger_test
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"fmt"
+
+	"github.com/SENG-499-Company2-B01/Backend/logger"
+)
+
+func TestLogger(t *testing.T) {
+	// Redirect log output to a buffer for testing
+	var buf bytes.Buffer
+
+	// Initialize the logger with the buffer as the output
+	logger.InitLogger(&buf, &buf, &buf)
+
+	// Test Info
+	expectedInfo := "\033[1;34m[INFO]\033[0m TestInfoMessage"
+	logger.Info("TestInfoMessage")
+
+	// Verify Info log message
+	if got := extractLogMessage(buf.String()); got != expectedInfo {
+		t.Errorf("Info log message:\nExpected: %q\nGot: %q", expectedInfo, got)
+	}
+
+	// Test Warning
+	expectedWarning := "\033[1;33m[WARNING]\033[0m logger_test.go:32 TestWarningMessage"
+	logger.Warning("TestWarningMessage")
+
+	// Verify Warning log message
+	if got := extractLogMessage(buf.String()); got != expectedWarning {
+		t.Errorf("Warning log message:\nExpected: %q\nGot: %q", expectedWarning, got)
+	}
+
+	// Turn off the exit on error to test successfully
+	logger.SetExitOnError(false)
+
+	// Test Error
+	expectedError := "\033[1;31m[ERROR]\033[0m logger_test.go:43 TestErrorMessage"
+	logger.Error(fmt.Errorf("TestErrorMessage"))
+
+	// Turn back on the exit on error 
+	logger.SetExitOnError(true)
+
+	// Verify Error log message
+	if got := extractLogMessage(buf.String()); got != expectedError {
+		t.Errorf("Error log message:\nExpected: %q\nGot: %q", expectedError, got)
+	}
+}
+
+func extractLogMessage(logOutput string) string {
+	// Split log output by newline characters
+	lines := strings.Split(strings.TrimSpace(logOutput), "\n")
+
+	// Get the last line of the log output
+	lastLine := lines[len(lines)-1]
+
+	// Split the last line by space characters
+	// The third element should be the log message without the date and time
+	parts := strings.SplitN(lastLine, " ", 3)
+
+	// Get the log message without the date and time
+	lastLineWithoutTimestamp := parts[2]
+
+	return lastLineWithoutTimestamp
+}
+
+func TestMain(m *testing.M) {
+	// Run tests
+	exitCode := m.Run()
+
+	// Clean up
+	log.SetOutput(os.Stderr)
+
+	// Exit with the appropriate exit code
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
This PR correlates to ticket [C2-19](https://seng499-b01-company2.atlassian.net/browse/C2-19) and correlates to setting up a basic logging package.

### Changes
- Added a basic logging file that handles info, warning and error logs depending on the situation
- The main.go file handles the logger initialization in init(), and as long as you import `"github.com/SENG-499-Company2-B01/Backend/logger"` at the top of a file you should be able to call the logger in any file in the project like:
```
logger.Info("This is an info message")
logger.Warning("This is a warning message")
logger.Error(fmt.Errorf("This is an error message"))
```
- Create a test file to test all of the logs from the console
- Added a global variable to exit the program on error logs, this emulates the log.Fatal process that an error log will most likely replace, this can be turned off and on like (this can be seen in the test file so it does not fail if the program exits during its testing):

```
logger.SetExitOnError(false)
logger.SetExitOnError(true)
```
- Below is an example of what is looks like in the console for all three variations of logs
![image](https://github.com/SENG-499-Company2-B01/Backend/assets/69998437/b65d97a1-94ea-4919-9a4f-223c3793083d)
