### PR TITLE
adding skeleton of schedule generation endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .env
 .vscode
 logs
+.mongo_pw
+.mongo_user

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 .env
 .vscode
 logs
-.mongo_pw
-.mongo_user

--- a/main.go
+++ b/main.go
@@ -186,6 +186,12 @@ func handleScheduleRequests(router *mux.Router) {
 	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
 		schedules.DeleteSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
 	}).Methods(http.MethodDelete)
+
+	// Run Schedule Generation
+	// NOTE: Still needs to implemented after algo team sets up REST APIs
+	router.HandleFunc("/generate_schedule", func(w http.ResponseWriter, r *http.Request) {
+		schedules.GenerateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+	}).Methods(http.MethodPost)
 }
 
 func main() {

--- a/modules/schedules/schedules.go
+++ b/modules/schedules/schedules.go
@@ -30,17 +30,36 @@ func GenerateSchedule(w http.ResponseWriter, r *http.Request, collection *mongo.
 
 	// Send a response indicating successful schedule creation
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "New Scheduled generated successfuly")
+	fmt.Fprintf(w, "New Scheduled generated successfully")
 }
 
 // CreateSchedule handles the creation of a new schedule
 func CreateSchedule(w http.ResponseWriter, r *http.Request, collection *mongo.Collection) {
 	fmt.Println("CreateSchedule function called.")
 
+	// Parse request body into Schedule struct
+	var newSchedule Schedule
+	err := json.NewDecoder(r.Body).Decode(&newSchedule)
+	if err != nil {
+		// If there is an error decoding the request body,
+		// return a bad request response
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Insert the schedule into the MongoDB collection
+	_, err = collection.InsertOne(context.TODO(), newSchedule)
+	if err != nil {
+		// If there is an error inserting the schedule into the collection,
+		// log the error and return an internal server error response
+		fmt.Println("Error inserting schedule:", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	// Send a response indicating successful schedule creation
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "New schedule created successfully")
+	fmt.Fprintf(w, "Schedule created successfully")
 }
 
 // GetSchedules retrieves all schedules from the MongoDB collection

--- a/modules/schedules/schedules.go
+++ b/modules/schedules/schedules.go
@@ -23,33 +23,24 @@ type Class struct {
 	Room    string `json:"room"`
 }
 
+// GenerateSchedule - Generates a new schedule
+// TODO: Still needs to be implemented once algo team sets up their REST API
+func GenerateSchedule(w http.ResponseWriter, r *http.Request, collection *mongo.Collection) {
+	fmt.Println("GenerateSchedule function called.")
+
+	// Send a response indicating successful schedule creation
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "New Scheduled generated successfuly")
+}
+
 // CreateSchedule handles the creation of a new schedule
 func CreateSchedule(w http.ResponseWriter, r *http.Request, collection *mongo.Collection) {
 	fmt.Println("CreateSchedule function called.")
 
-	// Parse request body into Schedule struct
-	var newSchedule Schedule
-	err := json.NewDecoder(r.Body).Decode(&newSchedule)
-	if err != nil {
-		// If there is an error decoding the request body,
-		// return a bad request response
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	// Insert the schedule into the MongoDB collection
-	_, err = collection.InsertOne(context.TODO(), newSchedule)
-	if err != nil {
-		// If there is an error inserting the schedule into the collection,
-		// log the error and return an internal server error response
-		fmt.Println("Error inserting schedule:", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 
 	// Send a response indicating successful schedule creation
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "Schedule created successfully")
+	fmt.Fprintf(w, "New schedule created successfully")
 }
 
 // GetSchedules retrieves all schedules from the MongoDB collection


### PR DESCRIPTION
The following endpoint is added:
- POST: /generate_schedule

Currently, the endpoint only returns status 200 and a success message. 

NOTE: This only adds a skeleton. The actual logic will come later when the algorithms team implements their APIs.
