### PR TITLE
adding api key authentication

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,4 @@ MONGO_PASSWORD=admin
 ADMIN_1=nobody.nobody 
 ADMIN_2=nobody.nobody 
 JWT_SECRET=secret
+API_HASH=fe80decbd03b2933f3d7eba3079e6b3e7c1bb2e3613f3671388c969fd6cd5aca

--- a/modules/helper/api_key.go
+++ b/modules/helper/api_key.go
@@ -1,0 +1,15 @@
+package helper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+)
+
+func VerifyAPIKey(keyPlainText string) bool {
+	hash := sha256.Sum256([]byte(keyPlainText))
+	if hex.EncodeToString(hash[:]) == os.Getenv("API_HASH") {
+		return true
+	}
+	return false
+}

--- a/modules/middleware/middleware.go
+++ b/modules/middleware/middleware.go
@@ -24,6 +24,19 @@ func Users_API_Access_Control(next http.Handler, collection *mongo.Collection) h
 			return
 		}
 
+		apikey := r.Header.Get("apikey")
+		if apikey != "" {
+			check := helper.VerifyAPIKey(apikey)
+			if check {
+				// Middleware successful
+				next.ServeHTTP(w, r)
+				return
+			}
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			logger.Error(fmt.Errorf("Unauthorized"), http.StatusUnauthorized)
+			return
+		}
+
 		auth := r.Header.Get("Authorization")
 		if auth == "" {
 			http.Error(w, "Unauthorized - Error no token provided", http.StatusUnauthorized)


### PR DESCRIPTION
This ticket aims at adding API key-based authentication for the Algorithm 1 and Algorithm 2 team. I have added the hash of the original key in the env file. This will be used to check when the actual key is received. Since we are only storing the hash of key in the env, the actual key cannot be determined by anyone.

Now the authentication middleware of the users endpoint will check first for and API key under "apikey" header. If a valid key is provided then that user can access all CRUD and all users information. If no API key is provided then the code will check for the jwt token. If the API key is invalid then it will throw a 401. 