### PR TITLE
Added logout endpoint and updated login to use username

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,9 +12,9 @@ import (
 	"github.com/SENG-499-Company2-B01/Backend/logger"
 	"github.com/SENG-499-Company2-B01/Backend/modules/classrooms"
 	"github.com/SENG-499-Company2-B01/Backend/modules/courses"
+	"github.com/SENG-499-Company2-B01/Backend/modules/middleware"
 	"github.com/SENG-499-Company2-B01/Backend/modules/schedules"
 	"github.com/SENG-499-Company2-B01/Backend/modules/users"
-	"github.com/SENG-499-Company2-B01/Backend/modules/middleware"
 
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
@@ -97,8 +97,11 @@ func handleUserRequests(router *mux.Router) {
 		return middleware.Users_API_Access_Control(next, client.Database("schedule_db").Collection("users"))
 	})
 	// AUTHENTICATION
-	router.HandleFunc("/signin", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		users.SignIn(w, r, client.Database("schedule_db").Collection("users"))
+	}).Methods(http.MethodPost)
+	router.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+		users.Logout(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodPost)
 
 	// Users CRUD Operations

--- a/modules/users/authentication.go
+++ b/modules/users/authentication.go
@@ -30,7 +30,7 @@ func SignIn(w http.ResponseWriter, r *http.Request, collection *mongo.Collection
 
 	var user User
 	// Retrieve the user credentials from the MongoDB collection
-	filter := bson.M{"email": signInReq.Email}
+	filter := bson.M{"username": signInReq.Username}
 	err = collection.FindOne(context.TODO(), filter).Decode(&user)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
@@ -42,7 +42,7 @@ func SignIn(w http.ResponseWriter, r *http.Request, collection *mongo.Collection
 		return
 	}
 
-	if signInReq.Email != user.Email || signInReq.Password != user.Password {
+	if signInReq.Username != user.Username || signInReq.Password != user.Password {
 		logger.Error(fmt.Errorf("username or Password Incorrect"), http.StatusNotFound)
 		http.Error(w, "Username or password incorrect.", http.StatusNotFound)
 		return
@@ -68,4 +68,10 @@ func SignIn(w http.ResponseWriter, r *http.Request, collection *mongo.Collection
 
 	// Uncomment the follow line for debugging
 	// logger.Info("Signin function completed.")
+}
+
+// Empty function to match partern company specs. Client will need to delete JWT.
+func Logout(w http.ResponseWriter, r *http.Request, collection *mongo.Collection) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Delete your token."))
 }


### PR DESCRIPTION
Updated the login logout endpoints to match the API specs. Login now uses the username and password passed as a body in the request (see image). Logout is an empty endpoint that returns a 200 OK along with a message to delete the JWT. Clients will be responsible for disposing of their tokens upon logout.

Jira Ticket: https://seng499-b01-company2.atlassian.net/browse/C2-49

![image](https://github.com/SENG-499-Company2-B01/Backend/assets/29262049/f5a004ae-4c7f-4c5b-afef-687ca0079e1a)
