### PR TITLE
Updated Schedule Endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func handleUserRequests(router *mux.Router) {
 	router.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		users.SignIn(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodPost)
+
 	router.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
 		users.Logout(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodPost)
@@ -199,31 +200,23 @@ func handleCourseRequests(router *mux.Router) {
 }
 
 func handleScheduleRequests(router *mux.Router) {
-	// Schedules CRUD Operations
+	// Schedules Read Operation
 	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
-		schedules.CreateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("draft_schedules"))
+	}).Methods(http.MethodGet)
+
+	// Schedules Generation Endpoints
+	router.HandleFunc("/schedules/{year}/{term}/generate", func(w http.ResponseWriter, r *http.Request) {
+		schedules.GenerateSchedule(w, r, client.Database("schedule_db").Collection("draft_schedules"))
 	}).Methods(http.MethodPost)
 
-	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("schedules"))
+	// Previous Schedule Operations
+	router.HandleFunc("/schedules/prev", func(w http.ResponseWriter, r *http.Request) {
+		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("previous_schedules"))
 	}).Methods(http.MethodGet)
 
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GetSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodGet)
-
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.UpdateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodPut)
-
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.DeleteSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodDelete)
-
-	// Run Schedule Generation
-	// NOTE: Still needs to implemented after algo team sets up REST APIs
-	router.HandleFunc("/generate_schedule", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GenerateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+	router.HandleFunc("/schedules/prev", func(w http.ResponseWriter, r *http.Request) {
+		schedules.ApproveSchedule(w, r, client.Database("schedule_db").Collection("draft_schedules"), client.Database("schedule_db").Collection("previous_schedules"))
 	}).Methods(http.MethodPost)
 }
 

--- a/mongodb/mongo-init.js
+++ b/mongodb/mongo-init.js
@@ -1,7 +1,7 @@
-db = db.getSiblingDB("schedule_db")
+db = db.getSiblingDB("schedule_db");
 
-
-db.createCollection("users") 
-db.createCollection("classrooms") 
-db.createCollection("courses") 
-db.createCollection("schedules")
+db.createCollection("users");
+db.createCollection("classrooms");
+db.createCollection("courses");
+db.createCollection("draft_schedules");
+db.createCollection("previous_schedules");

--- a/mongodb/scripts/.env
+++ b/mongodb/scripts/.env
@@ -1,8 +1,18 @@
-MONGO_ADDRESS=10.9.0.3
-MONGO_PORT=27017
-MONGO_USERNAME=admin
-MONGO_PASSWORD=admin 
+# Set this variable to 'production' or 'development'
+ENVIRONMENT=production
+
+# Development (local)
+MONGO_LOCAL_HOST=10.9.0.3:27017
+MONGO_LOCAL_USERNAME=admin
+MONGO_LOCAL_PASSWORD=admin 
+
+# Production (cloud)
+MONGO_PRODUCTION_HOST=company2-mongocluster.p0vfwcg.mongodb.net
+MONGO_PRODUCTION_USERNAME=admin
+MONGO_PRODUCTION_PASSWORD=LcKERy6JYJGNdfOZ
+
+# Shared
 ADMIN_1=rich.little 
 ADMIN_2=dan.mai 
-JWT_SECRET=secret 
-PW_SECRET=12345
+JWT_SECRET=secret
+API_HASH=fe80decbd03b2933f3d7eba3079e6b3e7c1bb2e3613f3671388c969fd6cd5aca

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -70,7 +70,7 @@ func init() {
 	mongohost := os.Getenv("MONGO_LOCAL_HOST")
 	mongoUsername := os.Getenv("MONGO_LOCAL_USERNAME")
 	mongoPassword := os.Getenv("MONGO_LOCAL_PASSWORD")
-	
+
 	// Set up the MongoDB client with SCRAM-SHA-1 authentication
 	clientOptions := options.Client().ApplyURI("mongodb://" + mongohost).
 		SetAuth(options.Credential{
@@ -189,31 +189,23 @@ func handleCourseRequests(router *mux.Router) {
 }
 
 func handleScheduleRequests(router *mux.Router) {
-	// Schedules CRUD Operations
+	// Schedules Read Operation
 	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
-		schedules.CreateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("draft_schedules"))
+	}).Methods(http.MethodGet)
+
+	// Schedules Generation Endpoints
+	router.HandleFunc("/schedules/{year}/{term}/generate", func(w http.ResponseWriter, r *http.Request) {
+		schedules.GenerateSchedule(w, r, client.Database("schedule_db").Collection("draft_schedules"))
 	}).Methods(http.MethodPost)
 
-	router.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("schedules"))
+	// Previous Schedule Operations
+	router.HandleFunc("/schedules/prev", func(w http.ResponseWriter, r *http.Request) {
+		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("previous_schedules"))
 	}).Methods(http.MethodGet)
 
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GetSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodGet)
-
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.UpdateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodPut)
-
-	router.HandleFunc("/schedules/{schedule}", func(w http.ResponseWriter, r *http.Request) {
-		schedules.DeleteSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
-	}).Methods(http.MethodDelete)
-
-	// Run Schedule Generation
-	// NOTE: Still needs to implemented after algo team sets up REST APIs
-	router.HandleFunc("/generate_schedule", func(w http.ResponseWriter, r *http.Request) {
-		schedules.GenerateSchedule(w, r, client.Database("schedule_db").Collection("schedules"))
+	router.HandleFunc("/schedules/prev", func(w http.ResponseWriter, r *http.Request) {
+		schedules.ApproveSchedule(w, r, client.Database("schedule_db").Collection("draft_schedules"), client.Database("schedule_db").Collection("previous_schedules"))
 	}).Methods(http.MethodPost)
 }
 


### PR DESCRIPTION
This PR correlates to ticket [C2-46](https://seng499-b01-company2.atlassian.net/browse/C2-46) which deals with changing the schedules endpoints and operations that we previously had to match the API doc.

### Changes
- Changed collection names in database to _draft_schedules_ and _previous_schedules_
- Updated and changed the operations used when an endpoint is hit with a requests. Removed unnecessary ones that will not be used anymore, and added ones for generating the schedule (skeleton for whoever coordinates with Algs1) and approving a schedule to move it from drafts into previous.
- Updated the routes for the endpoints to match the specifications