### PR TITLE
Update users endpoint to new API specs

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,6 +132,14 @@ func handleUserRequests(router *mux.Router) {
 
 	// Users CRUD Operations
 	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+		users.CreateUser(w, r, client.Database("schedule_db").Collection("users"))
+	}).Methods(http.MethodPost)
+
+	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+		users.CreateUser(w, r, client.Database("schedule_db").Collection("users"))
+	}).Methods(http.MethodPost)
+
+	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		users.GetUsers(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodGet)
 

--- a/main.go
+++ b/main.go
@@ -132,10 +132,6 @@ func handleUserRequests(router *mux.Router) {
 
 	// Users CRUD Operations
 	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
-		users.CreateUser(w, r, client.Database("schedule_db").Collection("users"))
-	}).Methods(http.MethodPost)
-
-	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		users.GetUsers(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodGet)
 
@@ -147,9 +143,6 @@ func handleUserRequests(router *mux.Router) {
 		users.UpdateUser(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodPut)
 
-	router.HandleFunc("/users/{username}", func(w http.ResponseWriter, r *http.Request) {
-		users.DeleteUser(w, r, client.Database("schedule_db").Collection("users"))
-	}).Methods(http.MethodDelete)
 }
 
 func handleClassroomRequests(router *mux.Router) {

--- a/modules/middleware/middleware.go
+++ b/modules/middleware/middleware.go
@@ -19,6 +19,43 @@ func setupCORS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding")
 }
 
+func fetch_email(path string, collection *mongo.Collection) string {
+
+	username := strings.TrimPrefix(path, "/users/")
+	username = strings.TrimSpace(username)
+
+	filter := bson.M{"username": username}
+	var user users.User
+	err := collection.FindOne(context.TODO(), filter).Decode(&user)
+
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			// If the user is not found,
+			// log the error and return a not found response
+			logger.Error(fmt.Errorf("user not found"), http.StatusNotFound)
+		} else {
+			logger.Error(fmt.Errorf("error getting user"), http.StatusInternalServerError)
+		}
+		return ""
+	}
+
+	return user.Email
+
+}
+
+func valid_permissions(r *http.Request, isAdmin bool, jwt_email string, collection *mongo.Collection) bool {
+
+	if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" || r.Method == "DELETE" {
+		if isAdmin {
+			return true
+		}
+		// If we have a non-admin token, a user can only update themselves
+		return jwt_email == fetch_email(r.URL.Path, collection)
+	}
+
+	return true
+}
+
 // Middleware function, which will be called for each request
 func Users_API_Access_Control(next http.Handler, collection *mongo.Collection) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -67,7 +104,7 @@ func Users_API_Access_Control(next http.Handler, collection *mongo.Collection) h
 		fmt.Println(token)
 
 		// user must be admin for CRUD operation on users
-		if (r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" || r.Method == "DELETE") && !jwtInfo.IsAdmin {
+		if !valid_permissions(r, jwtInfo.IsAdmin, jwtInfo.Email, collection) {
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			logger.Error(fmt.Errorf("Forbidden - CRUD operation requested by "+jwtInfo.Email), http.StatusForbidden)
 			return

--- a/mongodb/scripts/db_seed.py
+++ b/mongodb/scripts/db_seed.py
@@ -2,7 +2,8 @@ import pandas as pd
 from pymongo import MongoClient 
 from dotenv import load_dotenv
 import os  
-import bcrypt
+import bcrypt 
+
 
 def check_if_not_empty(coll,coll_name):  
 
@@ -46,7 +47,8 @@ def load_users(coll):
 
 
     users_df = pd.read_csv("users.csv").fillna('')
-    users_df = users_df.astype({'Credentials':'string'})
+    users_df = users_df.astype({'Credentials':'string'}) 
+    pref_dict = {"M":[[]],"T":[[]],"W":[[]],"R":[[]],"F":[[]]}
 
     for index, row in users_df.iterrows():
 
@@ -60,15 +62,17 @@ def load_users(coll):
         if user['username'].lower() == admin_1 or user['username'].lower() == admin_2:
             user['isAdmin'] = True
         else: 
-            user['isAdmin'] = False
+            user['isAdmin'] = False 
 
-        user['prefrences'] = []  
-
+        user['peng'] = (row['Peng'] == 1) 
+        user['pref_approved'] = False
+        user['max_courses'] = None
         # Convert qualifications string to array of strings 
       
         string_qualifications = row['Credentials'].replace("[","").replace("]","")
         qualifications = string_qualifications.split(",")
-        user['qualifications'] = qualifications
+        user['course_pref'] = qualifications 
+        user['unavailable'] = pref_dict 
 
         coll.insert_one(user)
 

--- a/mongodb/scripts/users.csv
+++ b/mongodb/scripts/users.csv
@@ -1,64 +1,64 @@
-Firstname,Lastname,Email,Credentials
-Celina,Berg,celinag@uvic.ca,"[CSC 111, SENG 310, SENG 435]"
-Bill,Bird,bbird@uvic.ca,"[CSC 111, CSC 355, SENG 310, SENG 435, SENG 466]"
-Sean,Chester,schester@uvic.ca,"[CSC 111, CSC 115, SENG 275, CSC 361, CSC 460]"
-Jason,Corless,-,"[CSC 111, CSC 115, CSC 225, CSC 226, CSC 230, CSC 355, CSC 361, CSC 460]"
-Daniela,Damian,danielad@uvic.ca,"[CSC 111, CSC 225, CSC 230, CSC 355, CSC 360, CSC 370, SENG 421]"
-Neil,Ernst,nernst@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 230, CSC 355, CSC 360, SENG 310, SENG 401, SENG 411, SENG 421, SENG 435, SENG 466, SENG 474]"
-Anthony,Estey,aestey@uvic.ca,"[CSC 115, CSC 226, SENG 275]"
-Sudhakar,Ganti,sganti@uvic.ca,"[CSC 111, CSC 115, CSC 355]"
-Daniel,German,dmg@uvic.ca,"[CSC 111, CSC 230, SENG 265, CSC 361, SENG 321, SENG 350, CSC 460, SENG 401, SENG 421]"
-Brandon,Haworth,bhaworth@uvic.ca,"[CSC 111, CSC 115, CSC 226, CSC 355, CSC 360]"
-Hosna,Jabbari,jabbari@uvic.ca,[CSC 111]
-LillAnne,Jackson,engradu@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, SENG 371]"
-Bruce,Kapron,bmkapron@uvic.ca,"[CSC 111, CSC 225, CSC 355, CSC 361, CSC 370]"
-Valerie,King,val@uvic.ca,"[CSC 230, SENG 265, CSC 370, SENG 321, SENG 350, SENG 360, SENG 401, SENG 421]"
-Sajin,Koroth,skoroth@uvic.ca,"[CSC 111, CSC 355, SENG 310, SENG 435, SENG 466]"
-Rich,Little,rlittle@uvic.ca,"[SENG 265, SENG 310, CSC 460, SENG 421, SENG 435, SENG 466]"
-Nishant,Mehta,nmehta@uvic.ca,"[CSC 115, CSC 226, SENG 275]"
-Hausi,Muller,hausi@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, CSC 230, SENG 265, SENG 275, CSC 320, CSC 355, CSC 360]"
-Miguel,Nacenta,nacenta@uvic.ca,"[CSC 230, SENG 310, SENG 321, SENG 421, SENG 435, SENG 466]"
-Ibrahim,Numanagić,inumanag@uvic.ca,"[SENG 310, SENG 435, SENG 474, CSC 330]"
-Jianping,Pan,pan@uvic.ca,"[CSC 226, SENG 371, SENG 421]"
-Charles,Perin,cperin@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, SENG 275, CSC 355, CSC 370, SENG 421]"
-Teseo,Schneider,teseo@uvic.ca,"[CSC 115, CSC 226, CSC 230, CSC 355, CSC 361, SENG 321, SENG 401, SENG 411]"
-Sowmya,Somanath,sowmyasomanath@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 230, CSC 320, CSC 355, CSC 360, CSC 361, SENG 350]"
-Venkatesh,Srinivasan,srinivas@uvic.ca,"[CSC 225, CSC 320, CSC 355, CSC 360, SENG 350]"
-Ulrike,Stege,ustege@uvic.ca,[CSC 115]
-Margaret-Anne,Storey,mstorey@uvic.ca,"[CSC 226, SENG 371, SENG 421]"
-Cecilia,Summers,-,"[CSC 226, SENG 275, SENG 421]"
-Alex,Thomo,thomo@uvic.ca,"[CSC 111, CSC 115, CSC 226, CSC 370, SENG 371]"
-George,Tzanetakis,gtzan@cs.uvic.ca,"[CSC 115, CSC 355, CSC 370, SENG 371]"
-Jens,Weber,jens@uvic.ca,"[CSC 230, SENG 321]"
-Kui,Wu,wkui@uvic.ca,"[CSC 111, CSC 225, CSC 230, CSC 355, CSC 360, SENG 360, SENG 411, SENG 421]"
-Michael,Zastre,zastre@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, CSC 230, SENG 275, CSC 355, CSC 360, SENG 310]"
-Michael,Adams,frodo@uvic.ca,"[ECE 260, SENG 475]"
-Panajotis,Agathoklis,panagath@ece.uvic.ca,"[ECE 310, ECE 360]"
-Riham,AlTawy,raltawy@uvic.ca,
-Amirali,Baniasadi,amiralib@uvic.ca,
-Jens,Bornemann,jbornema@ece.uvic.ca,
-Alexandra,Branzan Albu,aalbu@uvic.ca,
-Lin,Cai,cai@ece.uvic.ca,
-David,Capson,capson@uvic.ca,[ECE 355]
-Thomas,Darcie,tdarcie@uvic.ca,
-Nikitas,Dimopoulos,nikitas@ece.uvic.ca,
-Xiaodai,Dong,xdong@ece.uvic.ca,
-Peter,Driessen,peter@ece.uvic.ca,
-Fayez,Gebali,-,[ECE 360]
-Reuven,Gordon,rgordon@uvic.ca,
-Aaron,Gulliver,agullive@engr.uvic.ca,
-Kin Fun,Li,kinli@uvic.ca,
-Tao,Lu,taolu@ece.uvic.ca,
-Michael,McGuire,mmcguire@uvic.ca,"[ECE 310, ECE 360, ECE 485]"
-Stephen,Neville,sneville@ece.uvic.ca,"[ECE 485, SENG 468, SENG 499]"
-Christo,Papadopoulos,papdop@uvic.ca,
-Navneet,Popli,npopli@uvic.ca,"[SENG 499, SENG 468, ECE 458, SENG 275]"
-Daler,Rakhmatov,daler@ece.uvic.ca,
-Makhsud,Saidaminov,msaidaminov@uvic.ca,
-Sana,Shuja,sanashuja@uvic.ca,"[ECE 310, ECE 360, ECE 355]"
-Mihai,Sima,msima@ece.uvic.ca,[SENG 440]
-Levi,Smith,levismith@uvic.ca,
-Poman,So,poman.so@uvic.ca,
-Ilamparithi,Thirumarai Chelvan,ilampari@uvic.ca,
-Issa,Traore,itraore@ece.uvic.ca,
-Hong-Chuan,Yang,hy@uvic.ca,
+Firstname,Lastname,Email,Credentials,Peng
+Celina,Berg,celinag@uvic.ca,"[CSC 111, SENG 310, SENG 435]",0
+Bill,Bird,bbird@uvic.ca,"[CSC 111, CSC 355, SENG 310, SENG 435, SENG 466]",0
+Sean,Chester,schester@uvic.ca,"[CSC 111, CSC 115, SENG 275, CSC 361, CSC 460]",0
+Jason,Corless,-,"[CSC 111, CSC 115, CSC 225, CSC 226, CSC 230, CSC 355, CSC 361, CSC 460]",0
+Daniela,Damian,danielad@uvic.ca,"[CSC 111, CSC 225, CSC 230, CSC 355, CSC 360, CSC 370, SENG 421]",0
+Neil,Ernst,nernst@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 230, CSC 355, CSC 360, SENG 310, SENG 401, SENG 411, SENG 421, SENG 435, SENG 466, SENG 474]",0
+Anthony,Estey,aestey@uvic.ca,"[CSC 115, CSC 226, SENG 275]",0
+Sudhakar,Ganti,sganti@uvic.ca,"[CSC 111, CSC 115, CSC 355]",0
+Daniel,German,dmg@uvic.ca,"[CSC 111, CSC 230, SENG 265, CSC 361, SENG 321, SENG 350, CSC 460, SENG 401, SENG 421]",0
+Brandon,Haworth,bhaworth@uvic.ca,"[CSC 111, CSC 115, CSC 226, CSC 355, CSC 360]",0
+Hosna,Jabbari,jabbari@uvic.ca,[CSC 111],0
+LillAnne,Jackson,engradu@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, SENG 371]",0
+Bruce,Kapron,bmkapron@uvic.ca,"[CSC 111, CSC 225, CSC 355, CSC 361, CSC 370]",0
+Valerie,King,val@uvic.ca,"[CSC 230, SENG 265, CSC 370, SENG 321, SENG 350, SENG 360, SENG 401, SENG 421]",0
+Sajin,Koroth,skoroth@uvic.ca,"[CSC 111, CSC 355, SENG 310, SENG 435, SENG 466]",0
+Rich,Little,rlittle@uvic.ca,"[SENG 265, SENG 310, CSC 460, SENG 421, SENG 435, SENG 466]",0
+Nishant,Mehta,nmehta@uvic.ca,"[CSC 115, CSC 226, SENG 275]",0
+Hausi,Muller,hausi@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, CSC 230, SENG 265, SENG 275, CSC 320, CSC 355, CSC 360]",0
+Miguel,Nacenta,nacenta@uvic.ca,"[CSC 230, SENG 310, SENG 321, SENG 421, SENG 435, SENG 466]",0
+Ibrahim,Numanagić,inumanag@uvic.ca,"[SENG 310, SENG 435, SENG 474, CSC 330]",0
+Jianping,Pan,pan@uvic.ca,"[CSC 226, SENG 371, SENG 421]",0
+Charles,Perin,cperin@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, SENG 275, CSC 355, CSC 370, SENG 421]",0
+Teseo,Schneider,teseo@uvic.ca,"[CSC 115, CSC 226, CSC 230, CSC 355, CSC 361, SENG 321, SENG 401, SENG 411]",0
+Sowmya,Somanath,sowmyasomanath@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 230, CSC 320, CSC 355, CSC 360, CSC 361, SENG 350]",0
+Venkatesh,Srinivasan,srinivas@uvic.ca,"[CSC 225, CSC 320, CSC 355, CSC 360, SENG 350]",0
+Ulrike,Stege,ustege@uvic.ca,[CSC 115],0
+Margaret-Anne,Storey,mstorey@uvic.ca,"[CSC 226, SENG 371, SENG 421]",0
+Cecilia,Summers,-,"[CSC 226, SENG 275, SENG 421]",0
+Alex,Thomo,thomo@uvic.ca,"[CSC 111, CSC 115, CSC 226, CSC 370, SENG 371]",0
+George,Tzanetakis,gtzan@cs.uvic.ca,"[CSC 115, CSC 355, CSC 370, SENG 371]",0
+Jens,Weber,jens@uvic.ca,"[CSC 230, SENG 321]",1
+Kui,Wu,wkui@uvic.ca,"[CSC 111, CSC 225, CSC 230, CSC 355, CSC 360, SENG 360, SENG 411, SENG 421]",0
+Michael,Zastre,zastre@uvic.ca,"[CSC 111, CSC 115, CSC 225, CSC 226, CSC 230, SENG 275, CSC 355, CSC 360, SENG 310]",0
+Michael,Adams,frodo@uvic.ca,"[ECE 260, SENG 475]",1
+Panajotis,Agathoklis,panagath@ece.uvic.ca,"[ECE 310, ECE 360]",1
+Riham,AlTawy,raltawy@uvic.ca,,1
+Amirali,Baniasadi,amiralib@uvic.ca,,1
+Jens,Bornemann,jbornema@ece.uvic.ca,,1
+Alexandra,Branzan Albu,aalbu@uvic.ca,,1
+Lin,Cai,cai@ece.uvic.ca,,1
+David,Capson,capson@uvic.ca,[ECE 355],1
+Thomas,Darcie,tdarcie@uvic.ca,,1
+Nikitas,Dimopoulos,nikitas@ece.uvic.ca,,1
+Xiaodai,Dong,xdong@ece.uvic.ca,,1
+Peter,Driessen,peter@ece.uvic.ca,,1
+Fayez,Gebali,-,[ECE 360],1
+Reuven,Gordon,rgordon@uvic.ca,,1
+Aaron,Gulliver,agullive@engr.uvic.ca,,1
+Kin Fun,Li,kinli@uvic.ca,,1
+Tao,Lu,taolu@ece.uvic.ca,,1
+Michael,McGuire,mmcguire@uvic.ca,"[ECE 310, ECE 360, ECE 485]",1
+Stephen,Neville,sneville@ece.uvic.ca,"[ECE 485, SENG 468, SENG 499]",1
+Christo,Papadopoulos,papdop@uvic.ca,,1
+Navneet,Popli,npopli@uvic.ca,"[SENG 499, SENG 468, ECE 458, SENG 275]",1
+Daler,Rakhmatov,daler@ece.uvic.ca,,1
+Makhsud,Saidaminov,msaidaminov@uvic.ca,,1
+Sana,Shuja,sanashuja@uvic.ca,"[ECE 310, ECE 360, ECE 355]",1
+Mihai,Sima,msima@ece.uvic.ca,[SENG 440],1
+Levi,Smith,levismith@uvic.ca,,1
+Poman,So,poman.so@uvic.ca,,1
+Ilamparithi,Thirumarai Chelvan,ilampari@uvic.ca,,1
+Issa,Traore,itraore@ece.uvic.ca,,1
+Hong-Chuan,Yang,hy@uvic.ca,,1

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -70,7 +70,7 @@ func init() {
 	mongohost := os.Getenv("MONGO_LOCAL_HOST")
 	mongoUsername := os.Getenv("MONGO_LOCAL_USERNAME")
 	mongoPassword := os.Getenv("MONGO_LOCAL_PASSWORD")
-	
+
 	// Set up the MongoDB client with SCRAM-SHA-1 authentication
 	clientOptions := options.Client().ApplyURI("mongodb://" + mongohost).
 		SetAuth(options.Credential{
@@ -120,11 +120,6 @@ func handleUserRequests(router *mux.Router) {
 		users.SignIn(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodPost)
 
-	// Users CRUD Operations
-	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
-		users.CreateUser(w, r, client.Database("schedule_db").Collection("users"))
-	}).Methods(http.MethodPost)
-
 	router.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		users.GetUsers(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodGet)
@@ -136,10 +131,6 @@ func handleUserRequests(router *mux.Router) {
 	router.HandleFunc("/users/{username}", func(w http.ResponseWriter, r *http.Request) {
 		users.UpdateUser(w, r, client.Database("schedule_db").Collection("users"))
 	}).Methods(http.MethodPut)
-
-	router.HandleFunc("/users/{username}", func(w http.ResponseWriter, r *http.Request) {
-		users.DeleteUser(w, r, client.Database("schedule_db").Collection("users"))
-	}).Methods(http.MethodDelete)
 }
 
 func handleClassroomRequests(router *mux.Router) {


### PR DESCRIPTION
# C2-45 Update Users Endpoint 

## What's Changed 
In this PR we updated the /users endpoint to reflect the new agreed upon API specs. We removed the delete users endpoint since these are no longer required. We updated the user's json and we also changed permissions logic. Before, a user couldn't even add in their own preferences because only admin users can do POST/PUT requests. We have changed this logic so that users can also make changes to only themselves (i.e like adding a preference) 