### PR TITLE
Add operation fixes for schedules endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,12 +219,12 @@ func handleScheduleRequests(router *mux.Router) {
 		schedules.GetSchedules(w, r, client.Database("schedule_db").Collection("draft_schedules"))
 	}).Methods(http.MethodGet)
 
-	router.HandleFunc("/schedules/{year}", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/schedules/{year}/{term}", func(w http.ResponseWriter, r *http.Request) {
 		schedules.GetSchedule(w, r, client.Database("schedule_db").Collection("draft_schedules"))
 	}).Methods(http.MethodGet)
 
 	// Schedules Update Operation
-	router.HandleFunc("/schedules/{year}", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/schedules/{year}/{term}", func(w http.ResponseWriter, r *http.Request) {
 		schedules.UpdateSchedule(w, r, client.Database("schedule_db").Collection("draft_schedules"))
 	}).Methods(http.MethodPut)
 

--- a/mongodb/scripts/db_seed.py
+++ b/mongodb/scripts/db_seed.py
@@ -225,7 +225,7 @@ def db_seed():
     load_users(user_collection)
     load_courses(courses_collection) 
     load_classrooms(classrooms_collection) 
-    load_old_schedules(schedules_collection)
+    # load_old_schedules(schedules_collection)
 
 if __name__ == "__main__": 
     db_seed()


### PR DESCRIPTION
Just fixing up some small changes that were missed, Whoops!

### Changes
- Added term to the /schedules GET and PUT endpoints to be able to be more precise and stuff, this also included some better parsing of the request urls
- Fixed approve endpoint bug
- commented out the old schedules being added by the seed script because there is a bug in there making it so we can not get the schedules from the previous_schedules collection